### PR TITLE
Add necessary flags for naïve OS X support

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,11 +1,24 @@
 import Commander
 import PathKit
 
+private func target_specific_arguments() throws -> [String] {
+#if os(OSX)
+  return [
+    "-sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk",
+    "-target", "x86_64-apple-macosx10.10",
+    "-Xlinker", "-all_load",
+  ]
+#else
+  return []
+#endif
+}
+
 func build() throws {
   let libraries = Path.glob(".build/debug/*.a")
   let testSources = Path.glob("Tests/*.swift").map { $0.description }
 
-  let arguments = [
+  let arguments = try target_specific_arguments() + [
     "-o", ".build/debug/spectre-runner",
     "-I.build/debug",
   ] + libraries.map { "-Xlinker \($0)" } + testSources


### PR DESCRIPTION
We need to at least set `-target`, `-sdk` and pass `-all_load` to make it work.